### PR TITLE
Initial mem reclamation for larger data inputs

### DIFF
--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -167,7 +167,7 @@ multiexp_kernel(
 
     auto w_device = allocate_memory_async(w_size, strm, 1);
     auto out = allocate_memory_asnyc(out_size, strm, 1);
-    auto mults = allocate_memory_asnyc(get_aff_total_bytes<EC>(n_aff_pts), strm, 1);
+    auto mults = allocate_memory_async(get_aff_total_bytes<EC>(n_aff_pts), strm, 1);
     cudaMemcpyAsync(mults.get(), mults_host, get_aff_total_bytes<EC>(n_aff_pts), cudaMemcpyHostToDevice, strm);
     // cudaMemcpyAsync((void **)&w_device[0], w_host, w_size, cudaMemcpyHostToDevice, strm); 
     cudaMemcpyAsync(w_device.get(), w_host, w_size, cudaMemcpyHostToDevice, strm); 

--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -227,6 +227,10 @@ void run_prover(
     void *w_host = load_scalars_async_host(m + 1, inputs_file);
     // auto w_ = load_scalars_async(m + 1, inputs_file);
     rewind(inputs_file);
+    void *w_host2 = load_scalars_async_host(m + 1, inputs_file);
+    rewind(inputs_file);
+    void *w_host3 = load_scalars_async_host(m + 1, inputs_file);
+    rewind(inputs_file);
     auto inputs = B::read_input(inputs_file, d, m);
     fclose(inputs_file);
     print_time(t, "load inputs");
@@ -331,7 +335,7 @@ void run_prover(
     cudaMallocHost(&host_B2, out_size);
     // cudaMemcpyAsync((void **)&host_B2[0], out_B2.get(), out_size, cudaMemcpyDeviceToHost, sB2);
     // cudaFree(w2);
-    multiexp_kernel<ECpe, C, 2*R>(host_B2, w_host, w_size, B2_mults_host, out_size, ((1U << C) - 1)*(m + 1), m, sB2);
+    multiexp_kernel<ECpe, C, 2*R>(host_B2, w_host2, w_size, B2_mults_host, out_size, ((1U << C) - 1)*(m + 1), m, sB2);
     printf("finished ec reduce B2\n");
 
     var *host_L;
@@ -351,7 +355,7 @@ void run_prover(
     auto L_mults = allocate_memory(get_aff_total_bytes<ECp>(((1U << C) - 1)*(m - 1)), 1);
     cudaMemcpyAsync(L_mults.get(), L_mults_host, get_aff_total_bytes<ECp>(((1U << C) - 1)*(m - 1)), cudaMemcpyHostToDevice, sL);
     // cudaMemcpyAsync((void **)&w3[0], w_host, w_size, cudaMemcpyHostToDevice, sL); 
-    cudaMemcpyAsync(w3.get(), w_host, w_size, cudaMemcpyHostToDevice, sL); 
+    cudaMemcpyAsync(w3.get(), w_host3, w_size, cudaMemcpyHostToDevice, sL); 
 
     ec_reduce_straus<ECp, C, R>(sL, out_L.get(), L_mults.get(), w3.get() + (primary_input_size + 1) * ELT_LIMBS, m - 1);
     // var *host_L = (var *) malloc (out_size);

--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -166,7 +166,7 @@ multiexp_kernel(
     cudaStreamCreateWithFlags(&strm, cudaStreamNonBlocking);
 
     auto w_device = allocate_memory_async(w_size, strm, 1);
-    auto out = allocate_memory_asnyc(out_size, strm, 1);
+    auto out = allocate_memory_async(out_size, strm, 1);
     auto mults = allocate_memory_async(get_aff_total_bytes<EC>(n_aff_pts), strm, 1);
     cudaMemcpyAsync(mults.get(), mults_host, get_aff_total_bytes<EC>(n_aff_pts), cudaMemcpyHostToDevice, strm);
     // cudaMemcpyAsync((void **)&w_device[0], w_host, w_size, cudaMemcpyHostToDevice, strm); 

--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -325,7 +325,7 @@ void run_prover(
     auto out_B2 = allocate_memory_async(out_size, sB2, 1);
     auto B2_mults = allocate_memory_async(get_aff_total_bytes<ECpe>(((1U << C) - 1)*(m + 1)), sB2, 1);
     cudaMemcpyAsync(B2_mults.get(), B2_mults_host, get_aff_total_bytes<ECpe>(((1U << C) - 1)*(m + 1)), cudaMemcpyHostToDevice, sB2);
-    cudaMemcpyAsync(w2.get(), w_host, w_size, cudaMemcpyHostToDevice, sB2); 
+    cudaMemcpyAsync(w2.get(), w_host2, w_size, cudaMemcpyHostToDevice, sB2); 
 
     ec_reduce_straus<ECpe, C, 2*R>(sB2, out_B2.get(), B2_mults.get(), w2.get(), m + 1);
 
@@ -414,6 +414,8 @@ void run_prover(
     cudaFreeHost(B2_mults_host);
     cudaFreeHost(L_mults_host);
     cudaFreeHost(w_host);
+    cudaFreeHost(w_host2);
+    cudaFreeHost(w_host3);
     cudaFreeHost(host_B1);
     cudaFreeHost(host_B2);
     cudaFreeHost(host_L);

--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -322,7 +322,7 @@ void run_prover(
     cudaStreamCreateWithFlags(&sB2, cudaStreamNonBlocking);
 
     auto w2 = allocate_memory_async(w_size, sB2, 1);
-    auto out_B2 = allocate_memory_asnyc(out_size, sB2, 1);
+    auto out_B2 = allocate_memory_async(out_size, sB2, 1);
     auto B2_mults = allocate_memory_async(get_aff_total_bytes<ECpe>(((1U << C) - 1)*(m + 1)), sB2, 1);
     cudaMemcpyAsync(B2_mults.get(), B2_mults_host, get_aff_total_bytes<ECpe>(((1U << C) - 1)*(m + 1)), cudaMemcpyHostToDevice, sB2);
     cudaMemcpyAsync(w2.get(), w_host, w_size, cudaMemcpyHostToDevice, sB2); 

--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -417,7 +417,7 @@ void run_prover(
 
     // cudaFree(w1);
     // cudaFree(w2);
-    cudaFree(w3);
+    // cudaFree(w3);
 
     cudaFreeHost(B1_mults_host);
     cudaFreeHost(B2_mults_host);

--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -296,8 +296,8 @@ void run_prover(
     cudaStreamCreateWithFlags(&sB1, cudaStreamNonBlocking);
 
     auto w1 = allocate_memory_async(w_size, sB1, 1);
-    auto out_B1 = allocate_memory(out_size, sB1, 1);
-    auto B1_mults = allocate_memory(get_aff_total_bytes<ECp>(((1U << C) - 1)*(m + 1)), sB1, 1);
+    auto out_B1 = allocate_memory_async(out_size, sB1, 1);
+    auto B1_mults = allocate_memory_async(get_aff_total_bytes<ECp>(((1U << C) - 1)*(m + 1)), sB1, 1);
     
     cudaMemcpyAsync(B1_mults.get(), B1_mults_host, get_aff_total_bytes<ECp>(((1U << C) - 1)*(m + 1)), cudaMemcpyHostToDevice, sB1);
     cudaMemcpyAsync(w1.get(), w_host, w_size, cudaMemcpyHostToDevice, sB1); 
@@ -323,7 +323,7 @@ void run_prover(
 
     auto w2 = allocate_memory_async(w_size, sB2, 1);
     auto out_B2 = allocate_memory_asnyc(out_size, sB2, 1);
-    auto B2_mults = allocate_memory(get_aff_total_bytes<ECpe>(((1U << C) - 1)*(m + 1)), sB2, 1);
+    auto B2_mults = allocate_memory_async(get_aff_total_bytes<ECpe>(((1U << C) - 1)*(m + 1)), sB2, 1);
     cudaMemcpyAsync(B2_mults.get(), B2_mults_host, get_aff_total_bytes<ECpe>(((1U << C) - 1)*(m + 1)), cudaMemcpyHostToDevice, sB2);
     cudaMemcpyAsync(w2.get(), w_host, w_size, cudaMemcpyHostToDevice, sB2); 
 

--- a/multiexp/reduce.cu
+++ b/multiexp/reduce.cu
@@ -337,7 +337,7 @@ allocate_memory(size_t nbytes, int dbg = 0) {
 }
 
 var_ptr
-allocate_memory_async(cudaStream_t &strm, size_t nbytes, int dbg = 0) {
+allocate_memory_async(size_t nbytes, cudaStream_t &strm, int dbg = 0) {
     var *mem = nullptr;
     cudaMallocAsync(&mem, nbytes, strm);
     if (mem == nullptr) {

--- a/multiexp/reduce.cu
+++ b/multiexp/reduce.cu
@@ -247,7 +247,8 @@ template< typename EC, int C, int R >
 void
 ec_reduce_straus(cudaStream_t &strm, var *out, const var *multiples, const var *scalars, size_t N)
 {
-    cudaStreamCreate(&strm);
+    // Being created outside of method currently
+    // cudaStreamCreate(&strm);
 
     static constexpr size_t pt_limbs = EC::NELTS * ELT_LIMBS;
     size_t n = (N + R - 1) / R;


### PR DESCRIPTION
In order to handle massive memory inputs we need to reclaim memory as operations are completed and memcpy'd back to the host. This is the first beginning of this by utilizing separate methods for calling the kernels and taking advantage of the unique_ptr wrapper around device pointers (this can be found in multiexp/reduce.cu)